### PR TITLE
Lang-get fix to allow tab removal of last two variables.

### DIFF
--- a/snippets/Lang-get.sublime-snippet
+++ b/snippets/Lang-get.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[Lang::get(${1:key}, ${2:replace}, ${3:locale})]]></content>
+    <content><![CDATA[Lang::get(${1:key}${2:, ${3:replace}, ${4:locale}})]]></content>
     <tabTrigger>Lang-get</tabTrigger>
     <scope>source.php</scope>
 </snippet>


### PR DESCRIPTION
Using a nested tab action users can remove both $replace and $locale by tabbing for the second time.  Any tabs following that will allow the tab actions to function as normal.
